### PR TITLE
fix routes/login.js path to work correctly

### DIFF
--- a/routes/login.js
+++ b/routes/login.js
@@ -6,7 +6,7 @@ const router  = express.Router();
 const login_controller = require('../controllers/login_controller');
 const isAuthenticated = require('../config/middleware/isAuthenticated');
 
-router.get('/login', login_controller.index);
+router.get('/', login_controller.index);
 // router.get('/', isAuthenticated, dashboard_controller.index); will use this when authenication is implemented
 // router.post('/new', dashboard_controller.search);
 


### PR DESCRIPTION
fixed pathing in routes/login.js to read as just "/' so correct path for login view should read now as localhost:3005/login/